### PR TITLE
Add support for Apple Git-143

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
 
-# Testing that the tests still pass... They seem to with git version 2.37.1 (Apple Git-137.1), but not with git version 2.39.2 (Apple Git-143)
-
 jobs:
   build:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+# Testing that the tests still pass... They seem to with git version 2.37.1 (Apple Git-137.1), but not with git version 2.39.2 (Apple Git-143)
+
 jobs:
   build:
     runs-on: ${{matrix.os}}

--- a/count-todo
+++ b/count-todo
@@ -100,11 +100,11 @@ print_results() {
     fi
 }
 
-pattern="\(^\s*\|<!\-\-\|\-\-\|\*\|\#\|\/\/\|\*\)\s*\(TODO\|FIXME\|BUG\)\(\s\|\:\|,\).*"
+pattern="(^[ \t]*|^[ \t]*\*|<!--|--|\*|#|//|/\*)[ \t]*(TODO|FIXME|BUG)([ \t]|:|,).*"
 
 if [ "$all_commits" -eq "0" ]; then
     # Perform a search only on the current commit.
-    matches=`cd "$dir" && git grep --color=always --recursive --ignore-case -e $pattern --`
+    matches=`cd "$dir" && git grep --color=always --recursive --ignore-case -E "$pattern" --`
     commit_hash=`cd "$dir" && git rev-parse HEAD`
     commit_datetime=`cd "$dir" && git show -s --format=%ci`
     print_results "$matches" "$commit_hash" "$commit_datetime"
@@ -112,7 +112,7 @@ else
     # Perform a search for all commits.
     for commit_hash in $(cd "$dir" && git rev-list --all)
     do
-        matches=`cd "$dir" && git grep --color=always --recursive --ignore-case -e $pattern $commit_hash`
+        matches=`cd "$dir" && git grep --color=always --recursive --ignore-case -E "$pattern" $commit_hash`
         commit_datetime=`cd "$dir" && git show -s --format=%ci $commit_hash`
         print_results "$matches" "$commit_hash" "$commit_datetime"
     done


### PR DESCRIPTION
For whatever reason, `-e` doesn't work as a regex pattern on version Git 2.39.2 (Apple-Git 143).

It does work on Git 2.37.1 (Apple Git-137.1) and on whatever version Ubuntu uses in GitLab actions.

Switching to the extended regular expressions (`-E`) provided for `git grep` seem to work, and they make the regex look a lot cleaner.